### PR TITLE
Fix style missalignments on index page

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -20,28 +20,36 @@
     // box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
   }
 
-
   .container {
     // width: auto;
     margin: 0 0 20px 0;
     padding-left: 0;
     padding-right: 0;
+
+    &> div:first-child {
+      margin-bottom: 10px;
+
+      .btn-gemfinder {
+        padding: 0;
+      }
+    }
+
     .filters {
       display: flex;
       justify-content: space-between;
       align-items: flex-end;
+
       p, button {
         flex: 0 0 25%;
         font-size: 20px;
         margin-bottom: 0;
       }
+
       button {
         font-weight: bold;
       }
     }
   }
-
-
 
   .row {
     display: flex;
@@ -150,14 +158,14 @@
   }
 }
 
-.james {
-  display: flex !important;
-  justify-content: space-between !important;
-  h3 {
-    text-align: center;
-    margin: 5px;
-  }
-}
+// .james {
+//   display: flex !important;
+//   justify-content: space-between !important;
+//   h3 {
+//     text-align: center;
+//     margin: 5px;
+//   }
+// }
 
 .property-card-link {
   position: absolute;
@@ -260,4 +268,3 @@
   text-align: center;
   font-family: 'Open Sans', sans-serif;
 }
-

--- a/app/javascript/packs/map.js
+++ b/app/javascript/packs/map.js
@@ -18,7 +18,6 @@ if (mapElement) { // only build a map if there's a div#map to inject into
         .addTo(map);
   });
 
-
   // if (markers.length === 0) {
   //   map.setZoom(1);
   // } else if (markers.length === 1) {

--- a/app/views/properties/index.html.erb
+++ b/app/views/properties/index.html.erb
@@ -4,64 +4,65 @@
   </div>
   <div class="properties-wrapper">
       <div class="container">
-    <div class="">
-    <%= form_tag properties_path, class: "filters", method: :get do %>
-      <p><i class="fas fa-home"></i><%= text_field_tag :location, params[:location], class: "form-control", placeholder: "Location" %></p>
-      <p><i class="fas fa-bed"></i><%= number_field_tag :bedrooms, params[:bedrooms], class: "form-control", placeholder: "Bedrooms", min: 0, max: @max_bedrooms %></p>
-      <p><i class="fas fa-hand-holding-usd"></i><%= number_field_tag :price, params[:price], class: "form-control", placeholder: "Max Price" %></p>
-     <button class="btn btn-primary form-control" style="border-radius: 3px">Submit</button>
-     <% end %>
-    </div>
-     
-      <div class="row">
-        <% if @properties.empty? %>
-          <h3>No results match <%= params[:location] %></h1>
-        <% end %>
-        <% @properties.sample(30).each do |property| %>
-          <% next if property.price.nil? %>
-          <% next if property.photo_url.include?('noimage') %>
-          <% # All this should probably happen somewhere else %>
-          <% address_parts = property.address.split(',') %>
-          <% url = "http://api.postcodes.io/outcodes/#{property.postcode.outcode}" %>
-          <% response = JSON.parse(open(url).read) %>
-          <% area = response["result"]["admin_ward"][0] %>
-
-          <div class="col-xs-12 col-md-6 col-lg-6 inner-padded">
-            <div class="property-card">
-              <div class="property-card-header">
-                <p><%= address_parts[-1] %></p>
-                <h3><%= area %></h3>
-              </div>
-              <div class="property-card-thumbnail" style="background-image: url(<%= cl_image_path property.photo %>)"></div>
-              <div class="property-card-content">
-                <div class="james">
-                  <div class="fonts-awesome">
-                    <p><i class="fas fa-bed"></i>  <%= property.bedrooms %></p>
-                    <p><i class="fas fa-bath"></i> <%= property.bathrooms %></p>
-                    <p><i class="fas fa-car"></i>  <%= property.cars %></p>
-                  </div>
-                  <h3><%= address_parts[0] %></h3>
-                  <h6>£<%= property.price %></h6>
-                </div>
-                <p>
-                  <% content_max_len = 170 %>
-                  <% description = property.description.first(content_max_len) %>
-                  <% description += " [...]" if property.description.length > content_max_len %>
-                  <%= description %>
-                </p>
-              </div>
-              <div class="property-card-footer">
-                <a>More Info</a>
-                <a>Track</a>
-              </div>
-              <%= link_to "", property_path(property), class: "property-card-link" %>
-              <%= link_to "", trackings_path(tracking: {user_id: current_user.id, property_id: property.id }), method: :post, class: "property-card-track"  %>
-            </div>
-          </div>
+        <!-- Filters -->
+        <div>
+          <%= form_tag properties_path, class: "filters", method: :get do %>
+          <p><i class="fas fa-home"></i><%= text_field_tag :location, params[:location], class: "form-control", placeholder: "Location" %></p>
+          <p><i class="fas fa-bed"></i><%= number_field_tag :bedrooms, params[:bedrooms], class: "form-control", placeholder: "Bedrooms", min: 0, max: @max_bedrooms %></p>
+          <p><i class="fas fa-hand-holding-usd"></i><%= number_field_tag :price, params[:price], class: "form-control", placeholder: "Max Price" %></p>
+          <button class="btn btn-gemfinder form-control" style="border-radius: 3px">Submit</button>
           <% end %>
         </div>
-      </div>
-      <div id="map" data-markers="<%= @markers.to_json %>" data-mapbox-api-key="<%= ENV['MAPBOX_API_KEY']%>"></div>
+        <div class="row">
+          <!-- Results -->
+          <% if @properties.empty? %>
+            <h3>No results match <%= params[:location] %></h1>
+          <% end %>
+          <% @properties.sample(30).each do |property| %>
+            <% next if property.price.nil? %>
+            <% next if property.photo_url.include?('noimage') %>
+            <% # All this should probably happen somewhere else %>
+            <% address_parts = property.address.split(',') %>
+            <% url = "http://api.postcodes.io/outcodes/#{property.postcode.outcode}" %>
+            <% response = JSON.parse(open(url).read) %>
+            <% area = response["result"]["admin_ward"][0] %>
+
+            <div class="col-xs-12 col-md-6 col-lg-6 inner-padded">
+              <div class="property-card">
+                <div class="property-card-header">
+                  <p><%= address_parts[-1] %></p>
+                  <h3><%= area %></h3>
+                </div>
+                <div class="property-card-thumbnail" style="background-image: url(<%= cl_image_path property.photo %>)"></div>
+                <div class="property-card-content">
+                  <!-- Icons -->
+                  <div>
+                    <!-- <div class="fonts-awesome">
+                      <p><i class="fas fa-bed"></i>  <%= property.bedrooms %></p>
+                      <p><i class="fas fa-bath"></i> <%= property.bathrooms %></p>
+                      <p><i class="fas fa-car"></i>  <%= property.cars %></p>
+                    </div> -->
+                    <h3><%= address_parts[0] %></h3>
+                    <h6>£<%= property.price %></h6>
+                  </div>
+                  <p>
+                    <% content_max_len = 170 %>
+                    <% description = property.description.first(content_max_len) %>
+                    <% description += " [...]" if property.description.length > content_max_len %>
+                    <%= description %>
+                  </p>
+                </div>
+                <div class="property-card-footer">
+                  <a>More Info</a>
+                  <a>Track</a>
+                </div>
+                <%= link_to "", property_path(property), class: "property-card-link" %>
+                <%= link_to "", trackings_path(tracking: {user_id: current_user.id, property_id: property.id }), method: :post, class: "property-card-track"  %>
+              </div>
+            </div>
+            <% end %>
+          </div>
+        </div>
+      <!-- <div id="map"></div> -->
     </div>
-    <!-- <div id="map"></div> -->
   </div>

--- a/app/views/properties/index.html.erb
+++ b/app/views/properties/index.html.erb
@@ -43,7 +43,7 @@
                       <p><i class="fas fa-car"></i>  <%= property.cars %></p>
                     </div> -->
                     <h3><%= address_parts[0] %></h3>
-                    <h6>£<%= property.price %></h6>
+                    <h6>£<%= property.price.split(' ')[0] %></h6>
                   </div>
                   <p>
                     <% content_max_len = 170 %>


### PR DESCRIPTION
Had to remove the icons for bed, bath, etc since they were screwing with the property titles. Simply commented out for now. Can work on re-implementing them in a position that doesn't cramp the card if we want to. Current position was wrapping the title and offsetting card height.